### PR TITLE
check accounts and tokens ownership

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -83,7 +83,7 @@ export const robot = (app: Probot) => {
           const originalOwner = identity;
           let newOwner: string = '';
 
-          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}.json`));
+          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}/info.json`));
           if (infoJsonFile) {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
@@ -241,7 +241,6 @@ export const robot = (app: Probot) => {
 
         let { files: changedFiles, commits } = data.data;
 
-        await fail(`Processing the assets ownership checks for files: ${changedFiles}`);
         const lastCommitSha = commits[commits.length - 1].sha;
         const commitShas = commits.map(x => x.sha);
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -83,16 +83,23 @@ export const robot = (app: Probot) => {
           }
           const account = identity;
 
-          const apiUrl = getApiUrl();
-
-          const ownerResult = await axios.get(`${apiUrl}/accounts/${account}?extract=ownerAddress`);
-          const accountOwner = ownerResult.data;
+          const accountOwner = await getAccountOwnerFromApi(account);
           if (new Address(accountOwner).isContractAddress()) {
-            const ownerResult = await axios.get(`${apiUrl}/tokens/${accountOwner}?extract=ownerAddress`);
-            return ownerResult.data;
+            const newOwner = getAccountOwnerFromApi(accountOwner);
+            return newOwner;
           }
 
           return accountOwner;
+        }
+
+        async function getAccountOwnerFromApi(address: string): Promise<string> {
+          const apiUrl = getApiUrl();
+          const accountOwnerResponse = await axios.get(`${apiUrl}/accounts/${address}?extract=owner`);
+          if (accountOwnerResponse && accountOwnerResponse.data) {
+            return accountOwnerResponse.data;
+          }
+
+          return '';
         }
 
         async function getTokenOwner(): Promise<string> {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,7 +9,7 @@ export const robot = (app: Probot) => {
     async (context) => {
       try {
         const repo = context.repo();
-        context.log.info("Starting processing the assets ownership checks");
+        console.log("Starting processing the assets ownership checks");
 
         async function createComment(body: string) {
           try {
@@ -248,20 +248,19 @@ export const robot = (app: Probot) => {
 
         let checkMode = 'identity';
         const changedFilesNames = changedFiles.map(x => x.filename);
+        console.log({changedFiles});
         const distinctStakingIdentities = getDistinctIdentities(changedFilesNames);
         const distinctAccounts = getDistinctAccounts(changedFilesNames);
 
         const countDistinctStakingIdentities = distinctStakingIdentities.length;
         const countDistinctAccounts = distinctAccounts.length;
         if (countDistinctStakingIdentities === 0 && countDistinctAccounts === 0) {
-          context.log.info("No identity or account changed.");
           await fail("No identity or account changed.");
           return;
         }
 
         if (countDistinctAccounts) {
           if (countDistinctStakingIdentities) {
-            context.log.info("Only one identity or account update at a time.");
             await fail("Only one identity or account update at a time.");
             return;
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -82,7 +82,7 @@ export const robot = (app: Probot) => {
           const originalOwner = identity;
           let newOwner: string = '';
 
-          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}/info.json`));
+          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}.json`));
           if (infoJsonFile) {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
@@ -237,6 +237,7 @@ export const robot = (app: Probot) => {
 
         let { files: changedFiles, commits } = data.data;
 
+        console.log({changedFiles});
         const lastCommitSha = commits[commits.length - 1].sha;
         const commitShas = commits.map(x => x.sha);
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -63,12 +63,7 @@ export const robot = (app: Probot) => {
           const allOwners: string[] = [];
           const allOwnersToCheck = [mainOwner, ...extraOwners];
 
-          let apiUrl = 'https://next-api.multiversx.com';
-          if (network === 'devnet') {
-            apiUrl = 'https://devnet-api.multiversx.com';
-          } else if (network === 'testnet') {
-            apiUrl = 'https://testnet-api.multiversx.com';
-          }
+          const apiUrl = getApiUrl();
 
           for (const owner of allOwnersToCheck) {
             if (new Address(owner).isContractAddress()) {
@@ -88,12 +83,7 @@ export const robot = (app: Probot) => {
           }
           const account = identity;
 
-          let apiUrl = 'https://next-api.multiversx.com';
-          if (network === 'devnet') {
-            apiUrl = 'https://devnet-api.multiversx.com';
-          } else if (network === 'testnet') {
-            apiUrl = 'https://testnet-api.multiversx.com';
-          }
+          const apiUrl = getApiUrl();
 
           const ownerResult = await axios.get(`${apiUrl}/accounts/${account}?extract=ownerAddress`);
           const accountOwner = ownerResult.data;
@@ -113,13 +103,7 @@ export const robot = (app: Probot) => {
           }
           const token = identity;
 
-          let apiUrl = 'https://next-api.multiversx.com';
-          if (network === 'devnet') {
-            apiUrl = 'https://devnet-api.multiversx.com';
-          } else if (network === 'testnet') {
-            apiUrl = 'https://testnet-api.multiversx.com';
-          }
-
+          const apiUrl = getApiUrl();
 
           const tokenOwner = await getTokenOwnerFromApi(token, apiUrl);
           if (new Address(tokenOwner).isContractAddress()) {
@@ -137,6 +121,19 @@ export const robot = (app: Probot) => {
           }
 
           return '';
+        }
+
+        function getApiUrl() {
+          switch (network) {
+            case 'mainnet':
+              return 'https://next-api.multiversx.com';
+            case 'devnet':
+              return 'https://devnet-api.multiversx.com';
+            case 'testnet':
+              return 'https://testnet-api.multiversx.com';
+          }
+
+          throw new Error(`Invalid network: ${network}`);
         }
 
         function getDistinctNetworks(fileNames: string[]) {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -150,7 +150,7 @@ export const robot = (app: Probot) => {
         }
 
         function getDistinctAccounts(fileNames: string[]) {
-          const regex = /accounts\/(.*?)\//;
+          const regex = /accounts\/(.*?).json/;
 
           const accounts = fileNames
             .map(x => regex.exec(x)?.at(1))

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -226,7 +226,7 @@ export const robot = (app: Probot) => {
         const state = pullRequest.state;
 
         if (state === 'closed' || state === 'locked' || state === 'draft') {
-          context.log.error(`Invalid PR state: ${state}`);
+          await fail(`Invalid PR state: ${state}`);
           return 'invalid event payload';
         }
 
@@ -239,12 +239,12 @@ export const robot = (app: Probot) => {
 
         let { files: changedFiles, commits } = data.data;
 
-        context.log.info(`Processing the assets ownership checks for files: ${changedFiles}`);
+        await fail(`Processing the assets ownership checks for files: ${changedFiles}`);
         const lastCommitSha = commits[commits.length - 1].sha;
         const commitShas = commits.map(x => x.sha);
 
         if (!changedFiles?.length) {
-          context.log.info("No change detected.");
+          await fail("No change detected.");
           return 'no change';
         }
 
@@ -256,14 +256,14 @@ export const robot = (app: Probot) => {
         const countDistinctStakingIdentities = distinctStakingIdentities.length;
         const countDistinctAccounts = distinctAccounts.length;
         if (countDistinctStakingIdentities === 0 && countDistinctAccounts === 0) {
-          context.log.info("No identity or account changed.");
+          await fail("No identity or account changed.");
           await fail("No identity or account changed.");
           return;
         }
 
         if (countDistinctAccounts) {
           if (countDistinctStakingIdentities) {
-            context.log.info("Only one identity or account update at a time.");
+            await fail("Only one identity or account update at a time.");
             await fail("Only one identity or account update at a time.");
             return;
           }
@@ -274,7 +274,7 @@ export const robot = (app: Probot) => {
 
         const distinctNetworks = getDistinctNetworks(changedFiles.map(x => x.filename));
         if (distinctNetworks.length === 0) {
-          context.log.info("No network changed.");
+          await fail("No network changed.");
           return;
         }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -83,7 +83,7 @@ export const robot = (app: Probot) => {
           const originalOwner = identity;
           let newOwner: string = '';
 
-          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}/info.json`));
+          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}.info.json`));
           if (infoJsonFile) {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
@@ -323,6 +323,7 @@ export const robot = (app: Probot) => {
           return;
         }
 
+        console.log(`identity owners. check mode=${checkMode}. value=${owners}`);
         const invalidAddresses = await multiVerify(bodies, owners, commitShas);
         if (!invalidAddresses) {
           await fail('Failed to verify owners');

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -94,7 +94,7 @@ export const robot = (app: Probot) => {
 
         async function getAccountOwnerFromApi(address: string): Promise<string> {
           const apiUrl = getApiUrl();
-          const accountOwnerResponse = await axios.get(`${apiUrl}/accounts/${address}?extract=owner`);
+          const accountOwnerResponse = await axios.get(`${apiUrl}/accounts/${address}?extract=ownerAddress`);
           if (accountOwnerResponse && accountOwnerResponse.data) {
             return accountOwnerResponse.data;
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -83,12 +83,12 @@ export const robot = (app: Probot) => {
           const originalOwner = identity;
           let newOwner: string = '';
 
-          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}.info.json`));
+          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}.json`));
           if (infoJsonFile) {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
+            console.log(`typeof infoFromPullRequest = ${typeof infoFromPullRequest}. infoJsonFile=${infoJsonFile}. infoFromPullRequest=${infoFromPullRequest}`);
             if (infoFromPullRequest && typeof infoFromPullRequest === 'object') {
-              console.log(`typeof infoFromPullRequest = ${typeof infoFromPullRequest}. infoJsonFile=${infoJsonFile}. infoFromPullRequest=${infoFromPullRequest}`);
               newOwner = identity ?? '';
             }
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -253,7 +253,7 @@ export const robot = (app: Probot) => {
         const countDistinctStakingIdentities = distinctStakingIdentities.length;
         const countDistinctAccounts = distinctAccounts.length;
         if (countDistinctStakingIdentities === 0 && countDistinctAccounts === 0) {
-          console.log("No identities or accounts touched.");
+          await fail("No identities or accounts touched.");
           return;
         }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -39,7 +39,7 @@ export const robot = (app: Probot) => {
             originalOwners.push(...infoFromMaster.owners);
           }
 
-          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}/info.json`));
+          const infoJsonFile = files.find(x => x.filename.endsWith(`/${identity}.json`));
           if (infoJsonFile) {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
@@ -225,8 +225,6 @@ export const robot = (app: Probot) => {
         const { data: pullRequest } = await axios.get(`https://api.github.com/repos/multiversx/mx-assets/pulls/${context.pullRequest().pull_number}`);
         const state = pullRequest.state;
 
-        await fail(`State: ${state}`);
-
         if (state === 'closed' || state === 'locked' || state === 'draft') {
           await fail(`Invalid PR state: ${state}`);
           return 'invalid event payload';
@@ -245,7 +243,6 @@ export const robot = (app: Probot) => {
         const commitShas = commits.map(x => x.sha);
 
         if (!changedFiles?.length) {
-          await fail("No change detected.");
           return 'no change';
         }
 
@@ -257,14 +254,14 @@ export const robot = (app: Probot) => {
         const countDistinctStakingIdentities = distinctStakingIdentities.length;
         const countDistinctAccounts = distinctAccounts.length;
         if (countDistinctStakingIdentities === 0 && countDistinctAccounts === 0) {
-          await fail("No identity or account changed.");
+          context.log.info("No identity or account changed.");
           await fail("No identity or account changed.");
           return;
         }
 
         if (countDistinctAccounts) {
           if (countDistinctStakingIdentities) {
-            await fail("Only one identity or account update at a time.");
+            context.log.info("Only one identity or account update at a time.");
             await fail("Only one identity or account update at a time.");
             return;
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -78,7 +78,7 @@ export const robot = (app: Probot) => {
         }
 
         async function getAccountOwner(account: string): Promise<string> {
-         const accountOwner = await getAccountOwnerFromApi(account);
+          const accountOwner = await getAccountOwnerFromApi(account);
           if (new Address(accountOwner).isContractAddress()) {
             return getAccountOwnerFromApi(accountOwner);
           }
@@ -182,11 +182,11 @@ export const robot = (app: Probot) => {
         function getDistinctTokens(fileNames: string[]) {
           const regex = /tokens\/(.*?).json/;
 
-          const accounts = fileNames
+          const tokens = fileNames
             .map(x => regex.exec(x)?.at(1))
             .filter(x => x);
 
-          return [...new Set(accounts)];
+          return [...new Set(tokens)];
         }
 
         async function fail(reason: string) {
@@ -348,7 +348,7 @@ export const robot = (app: Probot) => {
         }
 
         const asset = distinctIdentities[0];
-        if(!asset) {
+        if (!asset) {
           await fail('No asset update detected');
           return;
         }
@@ -360,10 +360,12 @@ export const robot = (app: Probot) => {
             owners = await getIdentityOwners(changedFiles);
             break;
           case 'account':
-            owners = [...await getAccountOwner(asset)];
+            const accountOwner = await getAccountOwner(asset);
+            owners = [accountOwner];
             break;
           case 'token':
-            owners = [...await getTokenOwner(asset)];
+            const tokenOwner = await getTokenOwner(asset);
+            owners = [tokenOwner];
             break;
           default:
             owners = [];

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -78,7 +78,7 @@ export const robot = (app: Probot) => {
         }
 
         async function getAccountOwner(account: string): Promise<string> {
-          const accountOwner = await getAccountOwnerFromApi(account);
+          const accountOwner = account;
           if (new Address(accountOwner).isContractAddress()) {
             return getAccountOwnerFromApi(accountOwner);
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -88,6 +88,7 @@ export const robot = (app: Probot) => {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
             if (infoFromPullRequest && typeof infoFromPullRequest === 'object') {
+              console.log(`typeof infoFromPullRequest = ${typeof infoFromPullRequest}. infoJsonFile=${infoJsonFile}. infoFromPullRequest=${infoFromPullRequest}`);
               newOwner = identity ?? '';
             }
           }
@@ -100,7 +101,10 @@ export const robot = (app: Probot) => {
           }
 
           const allOwners: string[] = [];
-          let allOwnersToCheck = [newOwner];
+          let allOwnersToCheck: string[] = [];
+          if (newOwner) {
+            allOwnersToCheck = [...allOwnersToCheck, newOwner];
+          }
           if (originalOwner) {
             allOwnersToCheck = [...allOwnersToCheck, originalOwner];
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,6 +9,7 @@ export const robot = (app: Probot) => {
     async (context) => {
       try {
         const repo = context.repo();
+        console.log("Starting processing of the identities signatures");
 
         async function createComment(body: string) {
           try {
@@ -237,7 +238,7 @@ export const robot = (app: Probot) => {
 
         let { files: changedFiles, commits } = data.data;
 
-        console.log({changedFiles});
+        console.log({ changedFiles });
         const lastCommitSha = commits[commits.length - 1].sha;
         const commitShas = commits.map(x => x.sha);
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -90,7 +90,6 @@ export const robot = (app: Probot) => {
           if (infoJsonFile) {
             const { data: infoFromPullRequest } = await axios.get(infoJsonFile.raw_url);
 
-            console.log(`typeof infoFromPullRequest = ${typeof infoFromPullRequest}. infoJsonFile=${infoJsonFile}. infoFromPullRequest=${infoFromPullRequest}`);
             if (infoFromPullRequest && typeof infoFromPullRequest === 'object') {
               newOwner = identity ?? '';
             }
@@ -225,7 +224,7 @@ export const robot = (app: Probot) => {
           const signature = /[0-9a-fA-F]{128}/.exec(body)?.at(0);
           if (signature) {
             const verifyResult = await verifySignature(signature, address, message);
-            console.log(`verifying signature for address ${address}, message ${message}, and signature ${signature}. Result=${verifyResult}`);
+            console.log(`Verifying signature for address ${address}, message ${message}, and signature ${signature}. Result=${verifyResult}`);
             return verifyResult;
           }
 
@@ -306,7 +305,6 @@ export const robot = (app: Probot) => {
 
         let checkMode = 'identity';
         const changedFilesNames = changedFiles.map(x => x.filename);
-        console.log({ changedFiles });
         const distinctStakingIdentities = getDistinctIdentities(changedFilesNames);
         const distinctAccounts = getDistinctAccounts(changedFilesNames);
         const distinctTokens = getDistinctTokens(changedFilesNames);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,7 +9,7 @@ export const robot = (app: Probot) => {
     async (context) => {
       try {
         const repo = context.repo();
-        console.log("Starting processing of the identities signatures");
+        context.log.info("Starting processing the assets ownership checks");
 
         async function createComment(body: string) {
           try {
@@ -226,6 +226,7 @@ export const robot = (app: Probot) => {
         const state = pullRequest.state;
 
         if (state === 'closed' || state === 'locked' || state === 'draft') {
+          context.log.error(`Invalid PR state: ${state}`);
           return 'invalid event payload';
         }
 
@@ -238,11 +239,12 @@ export const robot = (app: Probot) => {
 
         let { files: changedFiles, commits } = data.data;
 
-        console.log({ changedFiles });
+        context.log.info(`Processing the assets ownership checks for files: ${changedFiles}`);
         const lastCommitSha = commits[commits.length - 1].sha;
         const commitShas = commits.map(x => x.sha);
 
         if (!changedFiles?.length) {
+          context.log.info("No change detected.");
           return 'no change';
         }
 
@@ -254,12 +256,14 @@ export const robot = (app: Probot) => {
         const countDistinctStakingIdentities = distinctStakingIdentities.length;
         const countDistinctAccounts = distinctAccounts.length;
         if (countDistinctStakingIdentities === 0 && countDistinctAccounts === 0) {
-          await fail("No identities or accounts touched.");
+          context.log.info("No identity or account changed.");
+          await fail("No identity or account changed.");
           return;
         }
 
         if (countDistinctAccounts) {
           if (countDistinctStakingIdentities) {
+            context.log.info("Only one identity or account update at a time.");
             await fail("Only one identity or account update at a time.");
             return;
           }
@@ -270,6 +274,7 @@ export const robot = (app: Probot) => {
 
         const distinctNetworks = getDistinctNetworks(changedFiles.map(x => x.filename));
         if (distinctNetworks.length === 0) {
+          context.log.info("No network changed.");
           return;
         }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -180,7 +180,7 @@ export const robot = (app: Probot) => {
         }
 
         function getDistinctTokens(fileNames: string[]) {
-          const regex = /tokens\/(.*?).json/;
+          const regex = /tokens\/(.*?)\/info.json/;
 
           const tokens = fileNames
             .map(x => regex.exec(x)?.at(1))

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -225,6 +225,8 @@ export const robot = (app: Probot) => {
         const { data: pullRequest } = await axios.get(`https://api.github.com/repos/multiversx/mx-assets/pulls/${context.pullRequest().pull_number}`);
         const state = pullRequest.state;
 
+        await fail(`State: ${state}`);
+
         if (state === 'closed' || state === 'locked' || state === 'draft') {
           await fail(`Invalid PR state: ${state}`);
           return 'invalid event payload';

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -124,15 +124,15 @@ export const robot = (app: Probot) => {
         }
 
         function getNetwork(fileName: string): 'mainnet' | 'devnet' | 'testnet' | undefined {
-          if (fileName.startsWith('identities')) {
+          if (fileName.startsWith('identities') || fileName.startsWith('accounts')) {
             return 'mainnet';
           }
 
-          if (fileName.startsWith('testnet/identities')) {
+          if (fileName.startsWith('testnet/identities') || fileName.startsWith('testnet/accounts')) {
             return 'testnet';
           }
 
-          if (fileName.startsWith('devnet/identities')) {
+          if (fileName.startsWith('devnet/identities') || fileName.startsWith('devnet/accounts')) {
             return 'devnet';
           }
 
@@ -248,7 +248,7 @@ export const robot = (app: Probot) => {
 
         let checkMode = 'identity';
         const changedFilesNames = changedFiles.map(x => x.filename);
-        console.log({changedFiles});
+        console.log({ changedFiles });
         const distinctStakingIdentities = getDistinctIdentities(changedFilesNames);
         const distinctAccounts = getDistinctAccounts(changedFilesNames);
 


### PR DESCRIPTION
Previously, only identities had ownership checks. Now this tool was extended to check tokens and account's owners as well